### PR TITLE
Quick fix

### DIFF
--- a/docs/how-to/index.mdx
+++ b/docs/how-to/index.mdx
@@ -18,3 +18,15 @@ SUAVE is focused on delivering credible, confidential computation that enables y
     - Builder solidity lets you request confidential computation, where your transaction data is encrypted to specific actors. Public contracts with verifiable logic, combined with confidential data, means that SUAVE can be seen as an open marketplace for mechanisms we can all inspect, collaborate on, and compete with to produce the most efficient MEV applications, while nevertheless protecting everyone's privacy.
 
 > **SUAVE enables anyone to build and deploy MEV applications, on a decentralized network, which were not possible until today.**  
+
+## Development Stack
+
+Here is an up-to-date list of software and repositories to help you build on [SUAVE Rigil](/technical/specs/rigil):
+
+- [Golang SDK](/how-to/interact-with-suave/golang-sdk)
+- [Typescript SDK: SUAVE-viem](/how-to/interact-with-suave/typescript-sdk)
+- [Example Golang Script](/how-to/interact-with-suave/deploy-and-test-example-suapp)
+- [SUAVE Rigil Specs](/technical/specs/rigil)
+- [SUAPP Examples Repo](https://github.com/flashbots/suapp-examples)
+- [suave-geth repo](https://github.com/flashbots/suave-geth)
+- [SAUVE Forge](https://github.com/flashbots/suave-geth/blob/main/suave/sol/libraries/SuaveForge.sol)

--- a/docs/novel-use-cases.mdx
+++ b/docs/novel-use-cases.mdx
@@ -11,32 +11,17 @@ keywords:
 
 # What to Build on SUAVE
 
-A good way to generate value is to design an app that is **uniquely enabled by SUAVE**.
+A good way to generate value is to design an app that is uniquely enabled by SUAVE.
 
-SUAVE exhibits two key differences to existing blockchains:
-
-2. Programmable privacy
-3. Credible off-chain computation
-
-## Development Stack
-
-First, here is an up-to-date list of software and repositories to help you build on [SUAVE Rigil](/technical/specs/rigil):
-
-- [Golang SDK](/how-to/interact-with-suave/golang-sdk)
-- [Typescript SDK: SUAVE-viem](/how-to/interact-with-suave/typescript-sdk)
-- [Example Golang Script](/how-to/interact-with-suave/deploy-and-test-example-suapp)
-- [SUAVE Rigil Specs](/technical/specs/rigil)
-- [SUAPP Examples Repo](https://github.com/flashbots/suapp-examples)
-- [suave-geth repo](https://github.com/flashbots/suave-geth)
-- [SAUVE Forge](https://github.com/flashbots/suave-geth/blob/main/suave/sol/libraries/SuaveForge.sol)
-
-## Confidential Computation
+Computation on SUAVE can be done in ways that are both **confidential** and **credible**. Lots of SUAPPs will leverage both of these features in different ways.
 
 :::info
 
 The categories on this page are deliberately broad. SUAPPs can make use of any, or all, of SUAVE's unique features. Do not feel that you need to stick to our suggestions or ways of categorising use cases
 
 :::
+
+## Confidential Computation
 
 These use cases leverage more of the confidential features of builder solidity contracts on SUAVE. They tend to focus more on *programmable privacy*.
 


### PR DESCRIPTION
Moves "Development Stack" from "What to Build" to "How To" index page.