### PR TITLE
Forge edits

### DIFF
--- a/docs/how-to/interact-with-suave/forge.mdx
+++ b/docs/how-to/interact-with-suave/forge.mdx
@@ -84,7 +84,21 @@ Then, run the Forge script with the `ffi` flag enabled:
 forge script Example.sol --ffi
 ```
 
-This should print the gas used to deploy your contract to your console. If you check the logs of your SUAVE devnet, you should see a message like this:
+<details>
+  <summary>Having issues?</summary>
+  <div>
+    <div>
+      <div>
+        Typically, building SUAVE yourself places the binary in the $GOPATH/bin directory. If it didn't happen, ensure that path is added to your PATH environment variable:<br/><br/>
+        <code>
+        export PATH=$PATH:$GOPATH/bin
+        </code>
+      </div>
+    </div>
+  </div>
+</details>
+
+The Forge script should print the gas used to run the specified function in your console. If you check the logs of your SUAVE devnet, you should see a message like this:
 
 `INFO [timestamp] confidential engine: refusing to send writes based on unsigned transaction`
 

--- a/docs/how-to/run-suave/build-yourself.mdx
+++ b/docs/how-to/run-suave/build-yourself.mdx
@@ -103,7 +103,7 @@ It should tell you the block height of your local network.
         </code><br/><br/>
         it is most likely because you have not set your GOPATH correctly. You can do so by running:<br/><br/>
         <code>
-        export PATH=$PATH:$GOPATH/bin
+        export GOPATH=$HOME/go
         </code>
       </div>
     </div>


### PR DESCRIPTION
Updates language to match rest of docs, and adds missing steps in instruction set required to make this work.

Still getting an error when running the script:

```
[⠔] Compiling...
[⠃] Compiling 9 files with 0.8.19
[⠊] Solc 0.8.19 finished in 1.25s
Compiler run successful with warnings:
Warning (2072): Unused local variable.
  --> suave-geth/suave/sol/libraries/SuaveForge.sol:63:9:
   |
63 |         bytes memory data = forgeIt("0x0000000000000000000000000000000042020000", abi.encode(bidId, key, data1));
   |         ^^^^^^^^^^^^^^^^^

Warning (2072): Unused local variable.
  --> src/example.sol:10:9:
   |
10 |         Suave.Bid memory bid = SuaveForge.newBid(
   |         ^^^^^^^^^^^^^^^^^^^^

Warning (2018): Function state mutability can be restricted to view
 --> src/example.sol:9:5:
  |
9 |     function example() public {
  |     ^ (Relevant source part starts here and spans across multiple lines).

Error: 
Function `run()` is not implemented in your script.
```

and will add a concluding sentence once everything is working as expected.