### PR TITLE
add forge instructions in 'Deploy Custom Contracts' page

### DIFF
--- a/docs/how-to/create-contracts/deploy-custom.mdx
+++ b/docs/how-to/create-contracts/deploy-custom.mdx
@@ -79,11 +79,11 @@ SUAVE contracts can be deployed using all existing Ethereum client providers (et
 # assuming you've already created a project with `forge init`
 forge build
 
-# defaults for a local devnet with suave-geth
 # replace these values with your own as needed
+export CONTRACT_NAME="MyContract"
+# defaults for a local devnet with suave-geth:
 export RPC_URL=http://localhost:8545
 export PRV_KEY=0x91ab9a7e53c220e6210460b65a7a3bb2ca181412a8a7b43ff336b3df1737ce12
-export CONTRACT_NAME="MyContract"
 
 # assuming your contract name (in code) is the same as the filename
 forge create --rpc-url $RPC_URL --private-key $PRV_KEY \


### PR DESCRIPTION
instructions for deploying contracts seemed a little complicated, so I added easy mode at the beginning